### PR TITLE
Change DBProxy primary identifier to name and remove rename code

### DIFF
--- a/aws-rds-dbproxy/aws-rds-dbproxy.json
+++ b/aws-rds-dbproxy/aws-rds-dbproxy.json
@@ -134,11 +134,12 @@
     "/properties/Endpoint"
   ],
   "createOnlyProperties": [
+    "/properties/DBProxyName",
     "/properties/EngineFamily",
     "/properties/VpcSubnetIds"
   ],
   "primaryIdentifier": [
-    "/properties/DBProxyArn"
+    "/properties/DBProxyName"
   ],
   "handlers": {
     "create": {

--- a/aws-rds-dbproxy/src/main/java/software/amazon/rds/dbproxy/UpdateHandler.java
+++ b/aws-rds-dbproxy/src/main/java/software/amazon/rds/dbproxy/UpdateHandler.java
@@ -183,7 +183,6 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                                                .withDBProxyName(oldModel.getDBProxyName())
                                                .withDebugLogging(newModel.getDebugLogging())
                                                .withIdleClientTimeout(newModel.getIdleClientTimeout())
-                                               .withNewDBProxyName(newModel.getDBProxyName())
                                                .withRequireTLS(newModel.getRequireTLS())
                                                .withRoleArn(newModel.getRoleArn())
                                                .withSecurityGroups(newModel.getVpcSecurityGroupIds());


### PR DESCRIPTION
*Description of changes:*
Change primary identifier of DBroxy to name instead of ARN. We lose the ability to rename without recreation but allows us to reference the proxy in TG stack. Matches RDS DBInstance and DBCluster. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
