### PR TITLE
Upgrade CFN version to 2.0

### DIFF
--- a/aws-rds-dbproxy/.rpdk-config
+++ b/aws-rds-dbproxy/.rpdk-config
@@ -10,6 +10,7 @@
             "amazon",
             "rds",
             "dbproxy"
-        ]
+        ],
+        "protocolVersion": "2.0.0"
     }
 }

--- a/aws-rds-dbproxy/pom.xml
+++ b/aws-rds-dbproxy/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.2</version>
+            <version>2.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-rds-dbproxy/src/main/java/software/amazon/rds/dbproxy/UpdateHandler.java
+++ b/aws-rds-dbproxy/src/main/java/software/amazon/rds/dbproxy/UpdateHandler.java
@@ -67,7 +67,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         // Update tags
         if (!callbackContext.isTagsDeregistered()) {
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                           .resourceModels(ImmutableList.of(oldModel, newModel))
+                           .resourceModel(newModel)
                            .status(OperationStatus.IN_PROGRESS)
                            .callbackContext(CallbackContext.builder()
                                                            .tagsDeregistered(deregisterOldTags(oldModel, newModel))
@@ -78,7 +78,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
 
         if (!callbackContext.isTagsRegistered()) {
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                           .resourceModels(ImmutableList.of(oldModel, newModel))
+                           .resourceModel(newModel)
                            .status(OperationStatus.IN_PROGRESS)
                            .callbackContext(CallbackContext.builder()
                                                            .tagsDeregistered(callbackContext.isTagsDeregistered())
@@ -91,7 +91,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         // Update proxy settings
         if (proxyStateSoFar == null) {
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                           .resourceModels(ImmutableList.of(oldModel, newModel))
+                           .resourceModel(newModel)
                            .status(OperationStatus.IN_PROGRESS)
                            .callbackContext(CallbackContext.builder()
                                                            .tagsDeregistered(callbackContext.isTagsDeregistered())
@@ -119,7 +119,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
 
             DBProxy proxy = updatedProxyProgress(proxyStateSoFar.getDBProxyName());
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                           .resourceModels(ImmutableList.of(oldModel, newModel))
+                           .resourceModel(newModel)
                            .status(OperationStatus.IN_PROGRESS)
                            .callbackContext(CallbackContext.builder()
                                                            .tagsDeregistered(callbackContext.isTagsDeregistered())

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/UpdateHandlerTest.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/UpdateHandlerTest.java
@@ -108,7 +108,7 @@ public class UpdateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).containsOnly(request.getDesiredResourceState(), request.getPreviousResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
     }
@@ -148,7 +148,7 @@ public class UpdateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).containsOnly(request.getDesiredResourceState(), request.getPreviousResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
@@ -195,7 +195,7 @@ public class UpdateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).containsOnly(request.getDesiredResourceState(), request.getPreviousResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
@@ -244,7 +244,7 @@ public class UpdateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).containsOnly(request.getDesiredResourceState(), request.getPreviousResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
@@ -297,7 +297,7 @@ public class UpdateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).containsOnly(request.getDesiredResourceState(), request.getPreviousResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 

--- a/aws-rds-dbproxytargetgroup/.rpdk-config
+++ b/aws-rds-dbproxytargetgroup/.rpdk-config
@@ -10,6 +10,7 @@
             "amazon",
             "rds",
             "dbproxytargetgroup"
-        ]
+        ],
+        "protocolVersion": "2.0.0"
     }
 }

--- a/aws-rds-dbproxytargetgroup/pom.xml
+++ b/aws-rds-dbproxytargetgroup/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.2</version>
+            <version>2.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-rds-dbproxytargetgroup/src/main/java/software/amazon/rds/dbproxytargetgroup/UpdateHandler.java
+++ b/aws-rds-dbproxytargetgroup/src/main/java/software/amazon/rds/dbproxytargetgroup/UpdateHandler.java
@@ -63,7 +63,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         // Update target-group settings
         if (callbackContext.getTargetGroupStatus() == null) {
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                           .resourceModels(ImmutableList.of(oldModel, newModel))
+                           .resourceModel(newModel)
                            .status(OperationStatus.IN_PROGRESS)
                            .callbackContext(CallbackContext.builder()
                                                            .targetGroupStatus(modifyProxyTargetGroup(oldModel, newModel))
@@ -75,7 +75,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         // Update registered databases
         if  (!callbackContext.isTargetsDeregistered()) {
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                           .resourceModels(ImmutableList.of(oldModel, newModel))
+                           .resourceModel(newModel)
                            .status(OperationStatus.IN_PROGRESS)
                            .callbackContext(CallbackContext.builder()
                                                            .targetGroupStatus(callbackContext.getTargetGroupStatus())
@@ -87,7 +87,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
 
         if (callbackContext.getTargets() == null) {
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                           .resourceModels(ImmutableList.of(oldModel, newModel))
+                           .resourceModel(newModel)
                            .status(OperationStatus.IN_PROGRESS)
                            .callbackContext(CallbackContext.builder()
                                                            .targetGroupStatus(callbackContext.getTargetGroupStatus())
@@ -102,7 +102,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
             boolean allTargetsHealthy = checkTargetHealth(newModel);
 
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                           .resourceModels(ImmutableList.of(oldModel, newModel))
+                           .resourceModel(newModel)
                            .status(OperationStatus.IN_PROGRESS)
                            .callbackContext(CallbackContext.builder()
                                .targetGroupStatus(callbackContext.getTargetGroupStatus())

--- a/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/CreateHandlerTest.java
+++ b/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/CreateHandlerTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -509,43 +510,8 @@ public class CreateHandlerTest {
     }
 
     @Test
-    public void testNotCreated(){
-        DBProxy dbProxy = new DBProxy().withStatus("creating");
-        doReturn(new DescribeDBProxiesResult().withDBProxies(dbProxy)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any());
-        final CreateHandler handler = new CreateHandler();
-
-        ImmutableList<String> clusterId = ImmutableList.of("clusterId");
-
-        final ResourceModel model = ResourceModel.builder().dBClusterIdentifiers(clusterId).build();
-
-        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                                                                      .desiredResourceState(model)
-                                                                      .build();
-
-        final CallbackContext context = CallbackContext.builder()
-                                                       .stabilizationRetriesRemaining(Constants.NUMBER_OF_STATE_POLL_RETRIES)
-                                                       .build();
-
-        final ProgressEvent<ResourceModel, CallbackContext> response
-                = handler.handleRequest(proxy, request, context, logger);
-
-        final CallbackContext desiredOutputContext = CallbackContext.builder()
-                                                                    .stabilizationRetriesRemaining(Constants.NUMBER_OF_STATE_POLL_RETRIES - 1)
-                                                                    .proxy(dbProxy)
-                                                                    .build();
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
-        assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
-    }
-
-    @Test
     public void testProxyDoesNotExist() {
-        doThrow(new DBProxyNotFoundException("")).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any());
+        doThrow(new DBProxyNotFoundException("")).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetGroupsRequest.class), any());
         final CreateHandler handler = new CreateHandler();
 
         final ResourceModel model = ResourceModel.builder().build();
@@ -558,20 +524,12 @@ public class CreateHandlerTest {
                                                        .stabilizationRetriesRemaining(Constants.NUMBER_OF_STATE_POLL_RETRIES)
                                                        .build();
 
-        final ProgressEvent<ResourceModel, CallbackContext> response
-                = handler.handleRequest(proxy, request, context, logger);
-
-        final CallbackContext desiredOutputContext = CallbackContext.builder()
-                                                                    .stabilizationRetriesRemaining(Constants.NUMBER_OF_STATE_POLL_RETRIES - 1)
-                                                                    .build();
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
-        assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        try {
+            handler.handleRequest(proxy, request, context, logger);
+            fail("Expect ProxyNotFound exception");
+        } catch (Exception e) {
+            assertThat(e instanceof DBProxyNotFoundException);
+        }
     }
 
     @Test

--- a/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/UpdateHandlerTest.java
+++ b/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/UpdateHandlerTest.java
@@ -153,7 +153,7 @@ public class UpdateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).containsOnly(request.getDesiredResourceState(), request.getPreviousResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
     }
@@ -242,7 +242,7 @@ public class UpdateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).containsOnly(request.getDesiredResourceState(), request.getPreviousResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
     }
@@ -286,7 +286,7 @@ public class UpdateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).containsOnly(request.getDesiredResourceState(), request.getPreviousResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
     }
@@ -324,7 +324,7 @@ public class UpdateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).containsOnly(request.getDesiredResourceState(), request.getPreviousResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
     }
@@ -371,7 +371,7 @@ public class UpdateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(desiredOutputContext);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModels()).containsOnly(request.getDesiredResourceState(), request.getPreviousResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
     }


### PR DESCRIPTION
*Description of changes:*
Upgrade CFN to version 2.
Requires an immediate ARN response so can't wait for proxy to become available in TG. 
Requires specifying a single model in UpdateHandlers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
