### PR TITLE
Add ignore array order for proxy

### DIFF
--- a/aws-rds-dbproxy/aws-rds-dbproxy.json
+++ b/aws-rds-dbproxy/aws-rds-dbproxy.json
@@ -55,6 +55,7 @@
     "Auth": {
       "description": "The authorization mechanism that the proxy uses.",
       "type": "array",
+      "insertionOrder": false,
       "minItems": 1,
       "items": {
         "$ref": "#/definitions/AuthFormat"
@@ -101,6 +102,7 @@
     "Tags": {
       "description": "An optional set of key-value pairs to associate arbitrary data of your choosing with the proxy.",
       "type": "array",
+      "insertionOrder": false,
       "items": {
         "$ref": "#/definitions/TagFormat"
       }
@@ -108,6 +110,7 @@
     "VpcSecurityGroupIds": {
       "description": "VPC security group IDs to associate with the new proxy.",
       "type": "array",
+      "insertionOrder": false,
       "minItems": 1,
       "items": {
         "type": "string"
@@ -116,6 +119,7 @@
     "VpcSubnetIds": {
       "description": "VPC subnet IDs to associate with the new proxy.",
       "type": "array",
+      "insertionOrder": false,
       "minItems": 2,
       "items": {
         "type": "string"

--- a/aws-rds-dbproxytargetgroup/aws-rds-dbproxytargetgroup.json
+++ b/aws-rds-dbproxytargetgroup/aws-rds-dbproxytargetgroup.json
@@ -25,6 +25,7 @@
         "SessionPinningFilters": {
           "description": "Each item in the list represents a class of SQL operations that normally cause all later statements in a session using a proxy to be pinned to the same underlying database connection.",
           "type": "array",
+          "insertionOrder": false,
           "items": {
             "type": "string"
           }
@@ -59,12 +60,14 @@
     },
     "DBInstanceIdentifiers": {
       "type": "array",
+      "insertionOrder": false,
       "items": {
         "type": "string"
       }
     },
     "DBClusterIdentifiers": {
       "type": "array",
+      "insertionOrder": false,
       "items": {
         "type": "string"
       }


### PR DESCRIPTION
*Description of changes:*
Adding "insertionOrder": false to proxy properties, so cloudformation can ignore order when comparing. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
