### PR TITLE
Update the unit test following changes in injectCredentialsAndInvoke

### DIFF
--- a/aws-rds-dbproxy/pom.xml
+++ b/aws-rds-dbproxy/pom.xml
@@ -21,7 +21,7 @@
     <repositories>
         <repository>
             <id>central</id>
-            <url>http://central.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
     </repositories>
 
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>[2.0.0, 3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/CreateHandlerTest.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/CreateHandlerTest.java
@@ -1,28 +1,29 @@
 package software.amazon.rds.dbproxy;
 
-import com.amazonaws.services.rds.model.CreateDBProxyRequest;
-import com.amazonaws.services.rds.model.CreateDBProxyResult;
-import com.amazonaws.services.rds.model.DBProxy;
-import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
-import com.amazonaws.services.rds.model.DescribeDBProxiesResult;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.util.function.Function;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.rds.model.CreateDBProxyRequest;
+import com.amazonaws.services.rds.model.CreateDBProxyResult;
+import com.amazonaws.services.rds.model.DBProxy;
+import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
+import com.amazonaws.services.rds.model.DescribeDBProxiesResult;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import java.util.function.Function;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest {

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/CreateHandlerTest.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/CreateHandlerTest.java
@@ -1,27 +1,28 @@
 package software.amazon.rds.dbproxy;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.amazonaws.services.rds.model.CreateDBProxyRequest;
 import com.amazonaws.services.rds.model.CreateDBProxyResult;
 import com.amazonaws.services.rds.model.DBProxy;
 import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
 import com.amazonaws.services.rds.model.DescribeDBProxiesResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest {
@@ -39,9 +40,10 @@ public class CreateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_InitialRunCreateProxy() {
         DBProxy dbProxy = new DBProxy().withStatus("creating");
-        doReturn(new CreateDBProxyResult().withDBProxy(dbProxy)).when(proxy).injectCredentialsAndInvoke(any(CreateDBProxyRequest.class), any());
+        doReturn(new CreateDBProxyResult().withDBProxy(dbProxy)).when(proxy).injectCredentialsAndInvoke(any(CreateDBProxyRequest.class), any(Function.class));
 
         final CreateHandler handler = new CreateHandler();
 
@@ -73,9 +75,10 @@ public class CreateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_Creating() {
         DBProxy dbProxy = new DBProxy().withStatus("creating");
-        doReturn(new DescribeDBProxiesResult().withDBProxies(dbProxy)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any());
+        doReturn(new DescribeDBProxiesResult().withDBProxies(dbProxy)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any(Function.class));
 
         final CreateHandler handler = new CreateHandler();
 

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/DeleteHandlerTest.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/DeleteHandlerTest.java
@@ -1,28 +1,29 @@
 package software.amazon.rds.dbproxy;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.amazonaws.services.rds.model.DBProxy;
 import com.amazonaws.services.rds.model.DBProxyNotFoundException;
 import com.amazonaws.services.rds.model.DeleteDBProxyRequest;
 import com.amazonaws.services.rds.model.DeleteDBProxyResult;
 import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
 import com.amazonaws.services.rds.model.DescribeDBProxiesResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest {
@@ -71,8 +72,9 @@ public class DeleteHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_alreadyDeletedTest() {
-        doThrow(new DBProxyNotFoundException("")).when(proxy).injectCredentialsAndInvoke(any(DeleteDBProxyRequest.class), any());
+        doThrow(new DBProxyNotFoundException("")).when(proxy).injectCredentialsAndInvoke(any(DeleteDBProxyRequest.class), any(Function.class));
 
         final DeleteHandler handler = new DeleteHandler();
 
@@ -104,9 +106,10 @@ public class DeleteHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_deleteTest() {
         DBProxy dbProxy = new DBProxy().withStatus("deleting");
-        doReturn(new DeleteDBProxyResult().withDBProxy(dbProxy)).when(proxy).injectCredentialsAndInvoke(any(DeleteDBProxyRequest.class), any());
+        doReturn(new DeleteDBProxyResult().withDBProxy(dbProxy)).when(proxy).injectCredentialsAndInvoke(any(DeleteDBProxyRequest.class), any(Function.class));
 
         final DeleteHandler handler = new DeleteHandler();
 
@@ -138,9 +141,10 @@ public class DeleteHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_deletingTest() {
         DBProxy dbProxy = new DBProxy().withStatus("deleting");
-        doReturn(new DescribeDBProxiesResult().withDBProxies(dbProxy)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any());
+        doReturn(new DescribeDBProxiesResult().withDBProxies(dbProxy)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any(Function.class));
 
         final DeleteHandler handler = new DeleteHandler();
 
@@ -173,10 +177,10 @@ public class DeleteHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_deletedTest() {
         DBProxy dbProxy = new DBProxy().withStatus("deleting");
-        //doReturn(new DescribeDBProxiesResult()).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any());
-        doThrow(new DBProxyNotFoundException("")).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any());
+        doThrow(new DBProxyNotFoundException("")).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any(Function.class));
 
         final DeleteHandler handler = new DeleteHandler();
 

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/DeleteHandlerTest.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/DeleteHandlerTest.java
@@ -1,29 +1,30 @@
 package software.amazon.rds.dbproxy;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.amazonaws.services.rds.model.DBProxy;
 import com.amazonaws.services.rds.model.DBProxyNotFoundException;
 import com.amazonaws.services.rds.model.DeleteDBProxyRequest;
 import com.amazonaws.services.rds.model.DeleteDBProxyResult;
 import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
 import com.amazonaws.services.rds.model.DescribeDBProxiesResult;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import java.util.function.Function;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest {

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/ListHandlerTest.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/ListHandlerTest.java
@@ -1,28 +1,29 @@
 package software.amazon.rds.dbproxy;
 
-import com.amazonaws.services.rds.model.DBProxy;
-import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
-import com.amazonaws.services.rds.model.DescribeDBProxiesResult;
-import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import java.util.List;
-import java.util.function.Function;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static software.amazon.rds.dbproxy.Matchers.assertThatModelsAreEqual;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.rds.model.DBProxy;
+import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
+import com.amazonaws.services.rds.model.DescribeDBProxiesResult;
+import com.google.common.collect.ImmutableList;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest {

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/ListHandlerTest.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/ListHandlerTest.java
@@ -1,28 +1,28 @@
 package software.amazon.rds.dbproxy;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static software.amazon.rds.dbproxy.Matchers.assertThatModelsAreEqual;
-
-import java.util.List;
-
+import com.amazonaws.services.rds.model.DBProxy;
+import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
+import com.amazonaws.services.rds.model.DescribeDBProxiesResult;
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import com.amazonaws.services.rds.model.DBProxy;
-import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
-import com.amazonaws.services.rds.model.DescribeDBProxiesResult;
-import com.google.common.collect.ImmutableList;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static software.amazon.rds.dbproxy.Matchers.assertThatModelsAreEqual;
 
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest {
@@ -40,6 +40,7 @@ public class ListHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_SimpleSuccess() {
         final ListHandler handler = new ListHandler();
 
@@ -51,7 +52,7 @@ public class ListHandlerTest {
 
         doReturn(new DescribeDBProxiesResult().withDBProxies(existingProxies))
                 .when(proxy)
-                .injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any());
+                .injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any(Function.class));
 
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/ReadHandlerTest.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/ReadHandlerTest.java
@@ -1,20 +1,5 @@
 package software.amazon.rds.dbproxy;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static software.amazon.rds.dbproxy.Matchers.assertThatModelsAreEqual;
-
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.amazonaws.services.rds.model.DBProxy;
 import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
 import com.amazonaws.services.rds.model.DescribeDBProxiesResult;
@@ -22,12 +7,27 @@ import com.amazonaws.services.rds.model.ListTagsForResourceRequest;
 import com.amazonaws.services.rds.model.ListTagsForResourceResult;
 import com.amazonaws.services.rds.model.Tag;
 import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static software.amazon.rds.dbproxy.Matchers.assertThatModelsAreEqual;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest {
@@ -45,6 +45,7 @@ public class ReadHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_SimpleSuccess() {
         final ReadHandler handler = new ReadHandler();
 
@@ -57,9 +58,9 @@ public class ReadHandlerTest {
 
         doReturn(new DescribeDBProxiesResult().withDBProxies(existingProxies))
                 .when(proxy)
-                .injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any());
+                .injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any(Function.class));
 
-        doReturn(new ListTagsForResourceResult()).when(proxy).injectCredentialsAndInvoke(any(ListTagsForResourceRequest.class), any());
+        doReturn(new ListTagsForResourceResult()).when(proxy).injectCredentialsAndInvoke(any(ListTagsForResourceRequest.class), any(Function.class));
 
         final ResourceModel model = ResourceModel.builder().dBProxyName("proxy1").build();
 
@@ -81,6 +82,7 @@ public class ReadHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_WithTags() {
         final ReadHandler handler = new ReadHandler();
 
@@ -93,7 +95,7 @@ public class ReadHandlerTest {
 
         doReturn(new DescribeDBProxiesResult().withDBProxies(existingProxies))
                 .when(proxy)
-                .injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any());
+                .injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any(Function.class));
 
         String tagKey = "tagKey";
         String tagValue = "tagValue";
@@ -103,7 +105,7 @@ public class ReadHandlerTest {
                                              new Tag().withKey(tagKey2).withValue(tagValue2));
         doReturn(new ListTagsForResourceResult().withTagList(tagList))
                 .when(proxy)
-                .injectCredentialsAndInvoke(any(ListTagsForResourceRequest.class), any());
+                .injectCredentialsAndInvoke(any(ListTagsForResourceRequest.class), any(Function.class));
 
         final ResourceModel model = ResourceModel.builder().dBProxyName("proxy1").build();
 
@@ -130,12 +132,13 @@ public class ReadHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_ResourceNotFound() {
         final ReadHandler handler = new ReadHandler();
 
         doReturn(new DescribeDBProxiesResult())
                 .when(proxy)
-                .injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any());
+                .injectCredentialsAndInvoke(any(DescribeDBProxiesRequest.class), any(Function.class));
 
         final ResourceModel model = ResourceModel.builder().dBProxyName("proxy1").build();
 

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/ReadHandlerTest.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/ReadHandlerTest.java
@@ -1,5 +1,21 @@
 package software.amazon.rds.dbproxy;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static software.amazon.rds.dbproxy.Matchers.assertThatModelsAreEqual;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.amazonaws.services.rds.model.DBProxy;
 import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
 import com.amazonaws.services.rds.model.DescribeDBProxiesResult;
@@ -7,27 +23,12 @@ import com.amazonaws.services.rds.model.ListTagsForResourceRequest;
 import com.amazonaws.services.rds.model.ListTagsForResourceResult;
 import com.amazonaws.services.rds.model.Tag;
 import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import java.util.List;
-import java.util.function.Function;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static software.amazon.rds.dbproxy.Matchers.assertThatModelsAreEqual;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest {

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/UpdateHandlerTest.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/UpdateHandlerTest.java
@@ -1,5 +1,21 @@
 package software.amazon.rds.dbproxy;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static software.amazon.rds.dbproxy.Constants.AVAILABLE_PROXY_STATE;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.amazonaws.services.rds.model.AddTagsToResourceRequest;
 import com.amazonaws.services.rds.model.DBProxy;
 import com.amazonaws.services.rds.model.ModifyDBProxyRequest;
@@ -7,26 +23,11 @@ import com.amazonaws.services.rds.model.ModifyDBProxyResult;
 import com.amazonaws.services.rds.model.RemoveTagsFromResourceRequest;
 import com.amazonaws.services.rds.model.Tag;
 import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import java.util.function.Function;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static software.amazon.rds.dbproxy.Constants.AVAILABLE_PROXY_STATE;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest {

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/UpdateHandlerTest.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/UpdateHandlerTest.java
@@ -1,19 +1,5 @@
 package software.amazon.rds.dbproxy;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static software.amazon.rds.dbproxy.Constants.AVAILABLE_PROXY_STATE;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.amazonaws.services.rds.model.AddTagsToResourceRequest;
 import com.amazonaws.services.rds.model.DBProxy;
 import com.amazonaws.services.rds.model.ModifyDBProxyRequest;
@@ -21,11 +7,26 @@ import com.amazonaws.services.rds.model.ModifyDBProxyResult;
 import com.amazonaws.services.rds.model.RemoveTagsFromResourceRequest;
 import com.amazonaws.services.rds.model.Tag;
 import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static software.amazon.rds.dbproxy.Constants.AVAILABLE_PROXY_STATE;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest {
@@ -75,9 +76,11 @@ public class UpdateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testModifyProxy() {
         DBProxy dbProxy = new DBProxy().withStatus(AVAILABLE_PROXY_STATE);
-        doReturn(new ModifyDBProxyResult().withDBProxy(dbProxy)).when(proxy).injectCredentialsAndInvoke(any(ModifyDBProxyRequest.class), any());
+        doReturn(new ModifyDBProxyResult().withDBProxy(dbProxy)).when(proxy).injectCredentialsAndInvoke(any(ModifyDBProxyRequest.class),
+                any(Function.class));
 
         final CallbackContext context = CallbackContext.builder()
                                                        .stabilizationRetriesRemaining(1)
@@ -111,6 +114,7 @@ public class UpdateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testDeregisterTags() {
         DBProxy dbProxy = new DBProxy().withStatus(AVAILABLE_PROXY_STATE);
         final CallbackContext context = CallbackContext.builder()
@@ -152,12 +156,13 @@ public class UpdateHandlerTest {
         assertThat(response.getErrorCode()).isNull();
 
         ArgumentCaptor<RemoveTagsFromResourceRequest> captor = ArgumentCaptor.forClass(RemoveTagsFromResourceRequest.class);
-        verify(proxy).injectCredentialsAndInvoke(captor.capture(), any());
+        verify(proxy).injectCredentialsAndInvoke(captor.capture(), any(Function.class));
         RemoveTagsFromResourceRequest removeTagsRequest = captor.getValue();
         assertThat(removeTagsRequest.getTagKeys().size()).isEqualTo(2);
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testRegisterTags() {
         DBProxy dbProxy = new DBProxy().withStatus(AVAILABLE_PROXY_STATE);
         final CallbackContext context = CallbackContext.builder()
@@ -202,12 +207,13 @@ public class UpdateHandlerTest {
         assertThat(response.getErrorCode()).isNull();
 
         ArgumentCaptor<AddTagsToResourceRequest> captor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(proxy).injectCredentialsAndInvoke(captor.capture(), any());
+        verify(proxy).injectCredentialsAndInvoke(captor.capture(), any(Function.class));
         AddTagsToResourceRequest removeTagsRequest = captor.getValue();
         assertThat(removeTagsRequest.getTags().size()).isEqualTo(2);
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testChangedTagValue_deregister() {
         DBProxy dbProxy = new DBProxy().withStatus(AVAILABLE_PROXY_STATE);
         final CallbackContext context = CallbackContext.builder()
@@ -254,13 +260,14 @@ public class UpdateHandlerTest {
         assertThat(response.getErrorCode()).isNull();
 
         ArgumentCaptor<RemoveTagsFromResourceRequest> captor = ArgumentCaptor.forClass(RemoveTagsFromResourceRequest.class);
-        verify(proxy).injectCredentialsAndInvoke(captor.capture(), any());
+        verify(proxy).injectCredentialsAndInvoke(captor.capture(), any(Function.class));
         RemoveTagsFromResourceRequest removeTagsRequest = captor.getValue();
         assertThat(removeTagsRequest.getTagKeys().size()).isEqualTo(1);
         assertThat(removeTagsRequest.getTagKeys().get(0)).isEqualTo(sharedKey);
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testChangedTagValue_Register() {
         DBProxy dbProxy = new DBProxy().withStatus(AVAILABLE_PROXY_STATE);
         final CallbackContext context = CallbackContext.builder()
@@ -310,7 +317,7 @@ public class UpdateHandlerTest {
         assertThat(response.getErrorCode()).isNull();
 
         ArgumentCaptor<AddTagsToResourceRequest> captor = ArgumentCaptor.forClass(AddTagsToResourceRequest.class);
-        verify(proxy).injectCredentialsAndInvoke(captor.capture(), any());
+        verify(proxy).injectCredentialsAndInvoke(captor.capture(), any(Function.class));
         AddTagsToResourceRequest addTagRequest = captor.getValue();
         assertThat(addTagRequest.getTags().size()).isEqualTo(1);
         Tag addedTag = addTagRequest.getTags().get(0);

--- a/aws-rds-dbproxytargetgroup/pom.xml
+++ b/aws-rds-dbproxytargetgroup/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>[2.0.0, 3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/CreateHandlerTest.java
+++ b/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/CreateHandlerTest.java
@@ -1,5 +1,22 @@
 package software.amazon.rds.dbproxytargetgroup;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.amazonaws.services.rds.model.ConnectionPoolConfigurationInfo;
 import com.amazonaws.services.rds.model.DBProxy;
 import com.amazonaws.services.rds.model.DBProxyNotFoundException;
@@ -15,27 +32,11 @@ import com.amazonaws.services.rds.model.RegisterDBProxyTargetsRequest;
 import com.amazonaws.services.rds.model.RegisterDBProxyTargetsResult;
 import com.amazonaws.services.rds.model.TargetHealth;
 import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest {

--- a/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/CreateHandlerTest.java
+++ b/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/CreateHandlerTest.java
@@ -5,8 +5,6 @@ import com.amazonaws.services.rds.model.DBProxy;
 import com.amazonaws.services.rds.model.DBProxyNotFoundException;
 import com.amazonaws.services.rds.model.DBProxyTarget;
 import com.amazonaws.services.rds.model.DBProxyTargetGroup;
-import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
-import com.amazonaws.services.rds.model.DescribeDBProxiesResult;
 import com.amazonaws.services.rds.model.DescribeDBProxyTargetGroupsRequest;
 import com.amazonaws.services.rds.model.DescribeDBProxyTargetGroupsResult;
 import com.amazonaws.services.rds.model.DescribeDBProxyTargetsRequest;
@@ -17,16 +15,20 @@ import com.amazonaws.services.rds.model.RegisterDBProxyTargetsRequest;
 import com.amazonaws.services.rds.model.RegisterDBProxyTargetsResult;
 import com.amazonaws.services.rds.model.TargetHealth;
 import com.google.common.collect.ImmutableList;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -34,9 +36,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest {
@@ -89,11 +88,13 @@ public class CreateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testModifyNoConnectionPoolConfig() {
         DBProxy dbProxy = new DBProxy().withStatus("available");
         ImmutableList<String> clusterId = ImmutableList.of("clusterId");
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup();
-        doReturn(new DescribeDBProxyTargetGroupsResult().withTargetGroups(dbProxyTargetGroup)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetGroupsRequest.class), any());
+        doReturn(new DescribeDBProxyTargetGroupsResult().withTargetGroups(dbProxyTargetGroup)).when(proxy)
+                .injectCredentialsAndInvoke(any(DescribeDBProxyTargetGroupsRequest.class), any(Function.class));
         final CreateHandler handler = new CreateHandler();
 
         final ResourceModel model = ResourceModel.builder().dBClusterIdentifiers(clusterId).build();
@@ -126,6 +127,7 @@ public class CreateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testModifyConnectionConfigProxy() {
         int connectionBorrowTimeout = 1;
         int maxConnectionsPercent = 25;
@@ -142,7 +144,8 @@ public class CreateHandlerTest {
                                                                                   .withSessionPinningFilters(sessionPinningFilters);
 
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup().withConnectionPoolConfig(connectionPoolConfigurationInfo);
-        doReturn(new ModifyDBProxyTargetGroupResult().withDBProxyTargetGroup(dbProxyTargetGroup)).when(proxy).injectCredentialsAndInvoke(any(ModifyDBProxyTargetGroupRequest.class), any());
+        doReturn(new ModifyDBProxyTargetGroupResult().withDBProxyTargetGroup(dbProxyTargetGroup)).when(proxy)
+                .injectCredentialsAndInvoke(any(ModifyDBProxyTargetGroupRequest.class), any(Function.class));
         final CreateHandler handler = new CreateHandler();
 
         ConnectionPoolConfigurationInfoFormat connectionPoolConfigurationInfo1 =
@@ -185,6 +188,7 @@ public class CreateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testCheckTargetHealth() {
         DBProxy dbProxy = new DBProxy().withStatus("available");
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup();
@@ -194,7 +198,7 @@ public class CreateHandlerTest {
                                        .withType("RDS_INSTANCE")
                                        .withTargetHealth(new TargetHealth().withState(Constants.AVAILABLE_STATE));
 
-        doReturn(new DescribeDBProxyTargetsResult().withTargets(target)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
+        doReturn(new DescribeDBProxyTargetsResult().withTargets(target)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
 
 
         final CreateHandler handler = new CreateHandler();
@@ -234,6 +238,7 @@ public class CreateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testCheckTargetHealth_nullInstanceHealth() {
         DBProxy dbProxy = new DBProxy().withStatus("available");
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup();
@@ -242,7 +247,7 @@ public class CreateHandlerTest {
                                        .withRdsResourceId("resourceId")
                                        .withType("RDS_INSTANCE");
 
-        doReturn(new DescribeDBProxyTargetsResult().withTargets(target)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
+        doReturn(new DescribeDBProxyTargetsResult().withTargets(target)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
 
 
         final CreateHandler handler = new CreateHandler();
@@ -282,6 +287,7 @@ public class CreateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testCheckTargetHealth_unhealthy() {
         DBProxy dbProxy = new DBProxy().withStatus("available");
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup();
@@ -291,7 +297,7 @@ public class CreateHandlerTest {
                                        .withType("RDS_INSTANCE")
                                        .withTargetHealth(new TargetHealth().withState("unhealthy"));
 
-        doReturn(new DescribeDBProxyTargetsResult().withTargets(target)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
+        doReturn(new DescribeDBProxyTargetsResult().withTargets(target)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
 
 
         final CreateHandler handler = new CreateHandler();
@@ -331,6 +337,7 @@ public class CreateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testCheckTargetHealth_cluster() {
         DBProxy dbProxy = new DBProxy().withStatus("available");
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup();
@@ -344,7 +351,8 @@ public class CreateHandlerTest {
                                        .withType("RDS_INSTANCE")
                                        .withTargetHealth(new TargetHealth().withState(Constants.AVAILABLE_STATE));
 
-        doReturn(new DescribeDBProxyTargetsResult().withTargets(target, targetCluster)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
+        doReturn(new DescribeDBProxyTargetsResult().withTargets(target, targetCluster)).when(proxy)
+                .injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
 
         final CreateHandler handler = new CreateHandler();
 
@@ -383,11 +391,12 @@ public class CreateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testCheckTargetHealth_noTargets() {
         DBProxy dbProxy = new DBProxy().withStatus("available");
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup();
         List<DBProxyTarget> proxyTargets = new ArrayList<>();
-        doReturn(new DescribeDBProxyTargetsResult()).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
+        doReturn(new DescribeDBProxyTargetsResult()).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
 
         final CreateHandler handler = new CreateHandler();
 
@@ -426,12 +435,14 @@ public class CreateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testRegistration_Available(){
         DBProxy dbProxy = new DBProxy().withStatus("available");
 
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup();
         DBProxyTarget dbProxyTarget = new DBProxyTarget();
-        doReturn(new RegisterDBProxyTargetsResult().withDBProxyTargets(dbProxyTarget)).when(proxy).injectCredentialsAndInvoke(any(RegisterDBProxyTargetsRequest.class), any());
+        doReturn(new RegisterDBProxyTargetsResult().withDBProxyTargets(dbProxyTarget)).when(proxy)
+                .injectCredentialsAndInvoke(any(RegisterDBProxyTargetsRequest.class), any(Function.class));
         final CreateHandler handler = new CreateHandler();
 
         ImmutableList<String> clusterId = ImmutableList.of("clusterId");
@@ -468,12 +479,14 @@ public class CreateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testRegistration_Creating(){
         DBProxy dbProxy = new DBProxy().withStatus("creating");
 
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup();
         DBProxyTarget dbProxyTarget = new DBProxyTarget();
-        doReturn(new RegisterDBProxyTargetsResult().withDBProxyTargets(dbProxyTarget)).when(proxy).injectCredentialsAndInvoke(any(RegisterDBProxyTargetsRequest.class), any());
+        doReturn(new RegisterDBProxyTargetsResult().withDBProxyTargets(dbProxyTarget)).when(proxy)
+                .injectCredentialsAndInvoke(any(RegisterDBProxyTargetsRequest.class), any(Function.class));
         final CreateHandler handler = new CreateHandler();
 
         ImmutableList<String> clusterId = ImmutableList.of("clusterId");
@@ -510,8 +523,9 @@ public class CreateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testProxyDoesNotExist() {
-        doThrow(new DBProxyNotFoundException("")).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetGroupsRequest.class), any());
+        doThrow(new DBProxyNotFoundException("")).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetGroupsRequest.class), any(Function.class));
         final CreateHandler handler = new CreateHandler();
 
         final ResourceModel model = ResourceModel.builder().build();

--- a/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/DeleteHandlerTest.java
+++ b/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/DeleteHandlerTest.java
@@ -1,27 +1,5 @@
 package software.amazon.rds.dbproxytargetgroup;
 
-import com.amazonaws.services.rds.model.DBProxyNotFoundException;
-import com.amazonaws.services.rds.model.DBProxyTarget;
-import com.amazonaws.services.rds.model.DeregisterDBProxyTargetsRequest;
-import com.amazonaws.services.rds.model.DescribeDBProxyTargetsRequest;
-import com.amazonaws.services.rds.model.DescribeDBProxyTargetsResult;
-import com.amazonaws.services.rds.model.InvalidDBProxyStateException;
-import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import java.util.ArrayList;
-import java.util.function.Function;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -29,6 +7,29 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.rds.model.DBProxyNotFoundException;
+import com.amazonaws.services.rds.model.DBProxyTarget;
+import com.amazonaws.services.rds.model.DeregisterDBProxyTargetsRequest;
+import com.amazonaws.services.rds.model.DescribeDBProxyTargetsRequest;
+import com.amazonaws.services.rds.model.DescribeDBProxyTargetsResult;
+import com.amazonaws.services.rds.model.InvalidDBProxyStateException;
+import com.google.common.collect.ImmutableList;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest {

--- a/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/DeleteHandlerTest.java
+++ b/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/DeleteHandlerTest.java
@@ -1,22 +1,5 @@
 package software.amazon.rds.dbproxytargetgroup;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import java.util.ArrayList;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.amazonaws.services.rds.model.DBProxyNotFoundException;
 import com.amazonaws.services.rds.model.DBProxyTarget;
 import com.amazonaws.services.rds.model.DeregisterDBProxyTargetsRequest;
@@ -24,12 +7,28 @@ import com.amazonaws.services.rds.model.DescribeDBProxyTargetsRequest;
 import com.amazonaws.services.rds.model.DescribeDBProxyTargetsResult;
 import com.amazonaws.services.rds.model.InvalidDBProxyStateException;
 import com.google.common.collect.ImmutableList;
-import jdk.nashorn.internal.ir.annotations.Immutable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.ArrayList;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest {
@@ -75,9 +74,10 @@ public class DeleteHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_DeregisterEmpty() {
         DescribeDBProxyTargetsResult emptyResult = new DescribeDBProxyTargetsResult();
-        doReturn(emptyResult).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
+        doReturn(emptyResult).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
 
         final DeleteHandler handler = new DeleteHandler();
 
@@ -109,13 +109,14 @@ public class DeleteHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_DeregisterInstance() {
         String instanceId= "instanceID";
         DescribeDBProxyTargetsResult describeResult = new DescribeDBProxyTargetsResult()
                                                               .withTargets(new DBProxyTarget()
                                                                                    .withRdsResourceId(instanceId)
                                                                                    .withType("RDS_INSTANCE"));
-        doReturn(describeResult).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
+        doReturn(describeResult).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
         final DeleteHandler handler = new DeleteHandler();
 
         final ResourceModel oldModel = ResourceModel.builder().dBInstanceIdentifiers(ImmutableList.of("db1")).build();
@@ -145,14 +146,15 @@ public class DeleteHandlerTest {
         assertThat(response.getErrorCode()).isNull();
 
         ArgumentCaptor<DeregisterDBProxyTargetsRequest> captor = ArgumentCaptor.forClass(DeregisterDBProxyTargetsRequest.class);
-        verify(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
-        verify(proxy, times(2)).injectCredentialsAndInvoke(captor.capture(), any());
+        verify(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
+        verify(proxy, times(2)).injectCredentialsAndInvoke(captor.capture(), any(Function.class));
         DeregisterDBProxyTargetsRequest deregisterDBProxyTargetsRequest = captor.getValue();
         assertThat(deregisterDBProxyTargetsRequest.getDBInstanceIdentifiers()).isEqualTo(ImmutableList.of(instanceId));
         assertThat(deregisterDBProxyTargetsRequest.getDBClusterIdentifiers().size()).isEqualTo(0);
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_DeregisterCluster() {
         String instanceId= "instanceID";
         String clusterName = "clusterName";
@@ -160,7 +162,7 @@ public class DeleteHandlerTest {
         DBProxyTarget cluster = new DBProxyTarget().withRdsResourceId(clusterName).withType("TRACKED_CLUSTER");
         DescribeDBProxyTargetsResult describeResult = new DescribeDBProxyTargetsResult()
                                                               .withTargets(instance, cluster);
-        doReturn(describeResult).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
+        doReturn(describeResult).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
         final DeleteHandler handler = new DeleteHandler();
 
         final ResourceModel oldModel = ResourceModel.builder().dBInstanceIdentifiers(ImmutableList.of("db1")).build();
@@ -190,16 +192,17 @@ public class DeleteHandlerTest {
         assertThat(response.getErrorCode()).isNull();
 
         ArgumentCaptor<DeregisterDBProxyTargetsRequest> captor = ArgumentCaptor.forClass(DeregisterDBProxyTargetsRequest.class);
-        verify(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
-        verify(proxy, times(2)).injectCredentialsAndInvoke(captor.capture(), any());
+        verify(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
+        verify(proxy, times(2)).injectCredentialsAndInvoke(captor.capture(), any(Function.class));
         DeregisterDBProxyTargetsRequest deregisterDBProxyTargetsRequest = captor.getValue();
         assertThat(deregisterDBProxyTargetsRequest.getDBClusterIdentifiers()).isEqualTo(ImmutableList.of(clusterName));
         assertThat(deregisterDBProxyTargetsRequest.getDBInstanceIdentifiers().size()).isEqualTo(0);
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_DeregisterProxyDeleted() {
-        doThrow(new DBProxyNotFoundException("")).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
+        doThrow(new DBProxyNotFoundException("")).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
 
         final DeleteHandler handler = new DeleteHandler();
 
@@ -230,8 +233,10 @@ public class DeleteHandlerTest {
         assertThat(response.getErrorCode()).isNull();
     }
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_DeregisterProxyDeleting() {
-        doThrow(new InvalidDBProxyStateException("DB Proxy prx-123 is in an unsupported state - DELETING, needs to be in [ACTIVE]")).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
+        doThrow(new InvalidDBProxyStateException("DB Proxy prx-123 is in an unsupported state - DELETING, needs to be in [ACTIVE]")).when(proxy)
+                .injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
 
         final DeleteHandler handler = new DeleteHandler();
 

--- a/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/ListHandlerTest.java
+++ b/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/ListHandlerTest.java
@@ -5,24 +5,25 @@ import com.amazonaws.services.rds.model.DBProxyTargetGroup;
 import com.amazonaws.services.rds.model.DescribeDBProxyTargetGroupsRequest;
 import com.amazonaws.services.rds.model.DescribeDBProxyTargetGroupsResult;
 import com.google.common.collect.ImmutableList;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.List;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static software.amazon.rds.dbproxytargetgroup.Matchers.assertThatModelsAreEqual;
-
-import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest {
@@ -40,6 +41,7 @@ public class ListHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_SimpleSuccess() {
         final ListHandler handler = new ListHandler();
 
@@ -56,7 +58,7 @@ public class ListHandlerTest {
         final List<DBProxyTargetGroup> existingProxies = ImmutableList.of(dbProxyTargetGroup1, dbProxyTargetGroup2);
 
         doReturn(new DescribeDBProxyTargetGroupsResult().withTargetGroups(existingProxies))
-                .when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetGroupsRequest.class), any());
+                .when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetGroupsRequest.class), any(Function.class));
 
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/ListHandlerTest.java
+++ b/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/ListHandlerTest.java
@@ -1,29 +1,30 @@
 package software.amazon.rds.dbproxytargetgroup;
 
-import com.amazonaws.services.rds.model.ConnectionPoolConfigurationInfo;
-import com.amazonaws.services.rds.model.DBProxyTargetGroup;
-import com.amazonaws.services.rds.model.DescribeDBProxyTargetGroupsRequest;
-import com.amazonaws.services.rds.model.DescribeDBProxyTargetGroupsResult;
-import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import java.util.List;
-import java.util.function.Function;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static software.amazon.rds.dbproxytargetgroup.Matchers.assertThatModelsAreEqual;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.rds.model.ConnectionPoolConfigurationInfo;
+import com.amazonaws.services.rds.model.DBProxyTargetGroup;
+import com.amazonaws.services.rds.model.DescribeDBProxyTargetGroupsRequest;
+import com.amazonaws.services.rds.model.DescribeDBProxyTargetGroupsResult;
+import com.google.common.collect.ImmutableList;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
 public class ListHandlerTest {

--- a/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/ReadHandlerTest.java
+++ b/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/ReadHandlerTest.java
@@ -3,24 +3,26 @@ package software.amazon.rds.dbproxytargetgroup;
 import com.amazonaws.services.rds.model.ConnectionPoolConfigurationInfo;
 import com.amazonaws.services.rds.model.DBProxyTarget;
 import com.amazonaws.services.rds.model.DBProxyTargetGroup;
-import com.amazonaws.services.rds.model.DescribeDBProxiesRequest;
 import com.amazonaws.services.rds.model.DescribeDBProxyTargetGroupsRequest;
 import com.amazonaws.services.rds.model.DescribeDBProxyTargetGroupsResult;
 import com.amazonaws.services.rds.model.DescribeDBProxyTargetsRequest;
 import com.amazonaws.services.rds.model.DescribeDBProxyTargetsResult;
 import com.amazonaws.services.rds.model.TargetType;
 import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -29,9 +31,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static software.amazon.rds.dbproxytargetgroup.Matchers.assertThatModelsAreEqual;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest {
@@ -52,6 +51,7 @@ public class ReadHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_SimpleSuccess() {
         final ReadHandler handler = new ReadHandler();
         ConnectionPoolConfigurationInfo connectionPoolConfigurationInfo = new ConnectionPoolConfigurationInfo();
@@ -67,12 +67,12 @@ public class ReadHandlerTest {
                                                                      .withTargetGroupName(DEFAULT_NAME);
         doReturn(new DescribeDBProxyTargetGroupsResult().withTargetGroups(existingProxies))
                 .when(proxy)
-                .injectCredentialsAndInvoke(eq(describeRequest), any());
+                .injectCredentialsAndInvoke(eq(describeRequest), any(Function.class));
 
         DescribeDBProxyTargetsRequest targetRequest = new DescribeDBProxyTargetsRequest()
                                                               .withDBProxyName(PROXY_NAME)
                                                               .withTargetGroupName(DEFAULT_NAME);
-        doReturn(new DescribeDBProxyTargetsResult()).when(proxy).injectCredentialsAndInvoke(eq(targetRequest), any());
+        doReturn(new DescribeDBProxyTargetsResult()).when(proxy).injectCredentialsAndInvoke(eq(targetRequest), any(Function.class));
 
         final ResourceModel model = ResourceModel.builder().dBProxyName(PROXY_NAME).targetGroupName(DEFAULT_NAME).build();
 
@@ -96,6 +96,7 @@ public class ReadHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_WithRegisteredCluster() {
         final ReadHandler handler = new ReadHandler();
         ConnectionPoolConfigurationInfo connectionPoolConfigurationInfo = new ConnectionPoolConfigurationInfo();
@@ -111,7 +112,7 @@ public class ReadHandlerTest {
                                                                      .withTargetGroupName(DEFAULT_NAME);
         doReturn(new DescribeDBProxyTargetGroupsResult().withTargetGroups(existingProxies))
                 .when(proxy)
-                .injectCredentialsAndInvoke(eq(describeRequest), any());
+                .injectCredentialsAndInvoke(eq(describeRequest), any(Function.class));
 
         DescribeDBProxyTargetsRequest targetRequest = new DescribeDBProxyTargetsRequest()
                                                                    .withDBProxyName(PROXY_NAME)
@@ -120,7 +121,7 @@ public class ReadHandlerTest {
         doReturn(new DescribeDBProxyTargetsResult()
                          .withTargets(new DBProxyTarget().withType(TargetType.TRACKED_CLUSTER).withRdsResourceId(clusterId),
                                       new DBProxyTarget().withType(TargetType.RDS_INSTANCE).withRdsResourceId("instanceId")))
-                .when(proxy).injectCredentialsAndInvoke(eq(targetRequest), any());
+                .when(proxy).injectCredentialsAndInvoke(eq(targetRequest), any(Function.class));
 
         final ResourceModel model = ResourceModel.builder().dBProxyName(PROXY_NAME).targetGroupName(DEFAULT_NAME).build();
 
@@ -145,6 +146,7 @@ public class ReadHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_defaultName() {
         final ReadHandler handler = new ReadHandler();
 
@@ -161,7 +163,7 @@ public class ReadHandlerTest {
                                                                      .withTargetGroupName(DEFAULT_NAME);
         doReturn(new DescribeDBProxyTargetGroupsResult().withTargetGroups(existingProxies))
                 .when(proxy)
-                .injectCredentialsAndInvoke(eq(describeRequest), any());
+                .injectCredentialsAndInvoke(eq(describeRequest), any(Function.class));
 
 
         final ResourceModel model = ResourceModel.builder().dBProxyName(PROXY_NAME).build();
@@ -184,11 +186,12 @@ public class ReadHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void handleRequest_ResourceNotFound() {
         final ReadHandler handler = new ReadHandler();
 
         doReturn(new DescribeDBProxyTargetGroupsResult())
-                .when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetGroupsRequest.class), any());
+                .when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetGroupsRequest.class), any(Function.class));
 
         final ResourceModel model = ResourceModel.builder().dBProxyName("proxy1").build();
 

--- a/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/ReadHandlerTest.java
+++ b/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/ReadHandlerTest.java
@@ -1,5 +1,22 @@
 package software.amazon.rds.dbproxytargetgroup;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static software.amazon.rds.dbproxytargetgroup.Matchers.assertThatModelsAreEqual;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.amazonaws.services.rds.model.ConnectionPoolConfigurationInfo;
 import com.amazonaws.services.rds.model.DBProxyTarget;
 import com.amazonaws.services.rds.model.DBProxyTargetGroup;
@@ -9,28 +26,12 @@ import com.amazonaws.services.rds.model.DescribeDBProxyTargetsRequest;
 import com.amazonaws.services.rds.model.DescribeDBProxyTargetsResult;
 import com.amazonaws.services.rds.model.TargetType;
 import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import java.util.List;
-import java.util.function.Function;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static software.amazon.rds.dbproxytargetgroup.Matchers.assertThatModelsAreEqual;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest {

--- a/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/UpdateHandlerTest.java
+++ b/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/UpdateHandlerTest.java
@@ -1,5 +1,20 @@
 package software.amazon.rds.dbproxytargetgroup;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.amazonaws.services.rds.model.ConnectionPoolConfigurationInfo;
 import com.amazonaws.services.rds.model.DBProxy;
 import com.amazonaws.services.rds.model.DBProxyTarget;
@@ -16,25 +31,11 @@ import com.amazonaws.services.rds.model.RegisterDBProxyTargetsRequest;
 import com.amazonaws.services.rds.model.RegisterDBProxyTargetsResult;
 import com.amazonaws.services.rds.model.TargetHealth;
 import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest {

--- a/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/UpdateHandlerTest.java
+++ b/aws-rds-dbproxytargetgroup/src/test/java/software/amazon/rds/dbproxytargetgroup/UpdateHandlerTest.java
@@ -16,24 +16,25 @@ import com.amazonaws.services.rds.model.RegisterDBProxyTargetsRequest;
 import com.amazonaws.services.rds.model.RegisterDBProxyTargetsResult;
 import com.amazonaws.services.rds.model.TargetHealth;
 import com.google.common.collect.ImmutableList;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest {
@@ -85,6 +86,7 @@ public class UpdateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testModifyTargetGroup() {
         int connectionBorrowTimeout = 1;
         int maxConnectionsPercent = 25;
@@ -102,7 +104,8 @@ public class UpdateHandlerTest {
                                                                                                                    .withSessionPinningFilters(sessionPinningFilters);
 
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup().withConnectionPoolConfig(connectionPoolConfigurationInfo);
-        doReturn(new ModifyDBProxyTargetGroupResult().withDBProxyTargetGroup(dbProxyTargetGroup)).when(proxy).injectCredentialsAndInvoke(any(ModifyDBProxyTargetGroupRequest.class), any());
+        doReturn(new ModifyDBProxyTargetGroupResult().withDBProxyTargetGroup(dbProxyTargetGroup)).when(proxy)
+                .injectCredentialsAndInvoke(any(ModifyDBProxyTargetGroupRequest.class), any(Function.class));
 
 
         final CallbackContext context = CallbackContext.builder()
@@ -159,11 +162,13 @@ public class UpdateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testModifyNoConnectionPoolConfig() {
         DBProxy dbProxy = new DBProxy().withStatus("available");
         ImmutableList<String> clusterId = ImmutableList.of("clusterId");
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup();
-        doReturn(new DescribeDBProxyTargetGroupsResult().withTargetGroups(dbProxyTargetGroup)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetGroupsRequest.class), any());
+        doReturn(new DescribeDBProxyTargetGroupsResult().withTargetGroups(dbProxyTargetGroup)).when(proxy)
+                .injectCredentialsAndInvoke(any(DescribeDBProxyTargetGroupsRequest.class), any(Function.class));
         final CreateHandler handler = new CreateHandler();
 
         final ResourceModel model = ResourceModel.builder().dBClusterIdentifiers(clusterId).build();
@@ -248,11 +253,13 @@ public class UpdateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testRegister() {
         DBProxy dbProxy = new DBProxy().withStatus("available");
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup();
         DBProxyTarget dbProxyTarget = new DBProxyTarget();
-        doReturn(new RegisterDBProxyTargetsResult().withDBProxyTargets(dbProxyTarget)).when(proxy).injectCredentialsAndInvoke(any(RegisterDBProxyTargetsRequest.class), any());
+        doReturn(new RegisterDBProxyTargetsResult().withDBProxyTargets(dbProxyTarget)).when(proxy)
+                .injectCredentialsAndInvoke(any(RegisterDBProxyTargetsRequest.class), any(Function.class));
         final UpdateHandler handler = new UpdateHandler();
 
         ImmutableList<String> clusterId = ImmutableList.of("clusterId");
@@ -292,9 +299,10 @@ public class UpdateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testDeregister() {
         DBProxyTargetGroup dbProxyTargetGroup = new DBProxyTargetGroup();
-        doReturn(new DeregisterDBProxyTargetsResult()).when(proxy).injectCredentialsAndInvoke(any(DeregisterDBProxyTargetsRequest.class), any());
+        doReturn(new DeregisterDBProxyTargetsResult()).when(proxy).injectCredentialsAndInvoke(any(DeregisterDBProxyTargetsRequest.class), any(Function.class));
         final UpdateHandler handler = new UpdateHandler();
 
         ImmutableList<String> instanceId = ImmutableList.of("instanceId");
@@ -330,6 +338,7 @@ public class UpdateHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testTargetHealth() {
         DBProxyTargetGroup defaultTargetGroup = new DBProxyTargetGroup();
         DBProxyTarget dbProxyTarget = new DBProxyTarget().withRdsResourceId("resourceId");
@@ -340,7 +349,7 @@ public class UpdateHandlerTest {
                                        .withType("RDS_INSTANCE")
                                        .withTargetHealth(new TargetHealth().withState(Constants.AVAILABLE_STATE));
 
-        doReturn(new DescribeDBProxyTargetsResult().withTargets(target)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any());
+        doReturn(new DescribeDBProxyTargetsResult().withTargets(target)).when(proxy).injectCredentialsAndInvoke(any(DescribeDBProxyTargetsRequest.class), any(Function.class));
         final CallbackContext context = CallbackContext.builder()
                                                        .targetGroupStatus(defaultTargetGroup)
                                                        .targets(targetList)


### PR DESCRIPTION
*Issue #18*

*Description of changes:*
cloudformation-cli-java-plugin made a change to overload injectCredentialsAndInvoke, this breaks our unit test. The change is to fix the build.
https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/pull/338

Update the pom.xml for the repository url, as http was no longer supported.

Update the aws-cloudformation-rpdk-java-plugin version to [2.0.0, 3.0.0)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
