### PR TITLE
Add VPC Id property to proxy for proxy API update in aws-java-sdk-rds 1.11.971

### DIFF
--- a/aws-rds-dbproxy/.rpdk-config
+++ b/aws-rds-dbproxy/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::RDS::DBProxy",
     "language": "java",
     "runtime": "java8",
@@ -12,5 +13,6 @@
             "dbproxy"
         ],
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.rds.dbproxy.HandlerWrapperExecutable"
 }

--- a/aws-rds-dbproxy/aws-rds-dbproxy.json
+++ b/aws-rds-dbproxy/aws-rds-dbproxy.json
@@ -33,7 +33,8 @@
           "description": "The name of the database user to which the proxy connects.",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "TagFormat": {
       "type": "object",
@@ -48,7 +49,8 @@
           "pattern": "(\\w|\\d|\\s|\\\\|-|\\.:=+-)*",
           "maxLength": 128
         }
-      }
+      },
+      "additionalProperties": false
     }
   },
   "properties": {
@@ -107,6 +109,10 @@
         "$ref": "#/definitions/TagFormat"
       }
     },
+    "VpcId": {
+      "description": "VPC ID to associate with the new DB proxy.",
+      "type": "string"
+    },
     "VpcSecurityGroupIds": {
       "description": "VPC security group IDs to associate with the new proxy.",
       "type": "array",
@@ -136,7 +142,8 @@
   ],
   "readOnlyProperties": [
     "/properties/DBProxyArn",
-    "/properties/Endpoint"
+    "/properties/Endpoint",
+    "/properties/VpcId"
   ],
   "createOnlyProperties": [
     "/properties/DBProxyName",

--- a/aws-rds-dbproxy/pom.xml
+++ b/aws-rds-dbproxy/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-rds</artifactId>
-            <version>1.11.699</version>
+            <version>[1.11.971, 2.0.0)</version>
         </dependency>
     </dependencies>
 

--- a/aws-rds-dbproxy/src/main/java/software/amazon/rds/dbproxy/Utility.java
+++ b/aws-rds-dbproxy/src/main/java/software/amazon/rds/dbproxy/Utility.java
@@ -15,35 +15,36 @@ import com.amazonaws.services.rds.model.UserAuthConfigInfo;
 public class Utility {
     static <A, B> List<B> map(Collection<A> xs, Function<A, B> f) {
         return Optional.ofNullable(xs).orElse(Collections.emptyList()).stream().map(f)
-                       .collect(Collectors.toList());
+                .collect(Collectors.toList());
     }
 
     public static ResourceModel resultToModel(DBProxy proxy){
         List<AuthFormat> authModels = proxy.getAuth().stream().map(a -> resultToModel(a)).collect(Collectors.toList());
         return ResourceModel
-                       .builder()
-                       .auth(authModels)
-                       .dBProxyArn(proxy.getDBProxyArn())
-                       .dBProxyName(proxy.getDBProxyName())
-                       .debugLogging(proxy.getDebugLogging())
-                       .endpoint(proxy.getEndpoint())
-                       .engineFamily(proxy.getEngineFamily())
-                       .idleClientTimeout(proxy.getIdleClientTimeout())
-                       .requireTLS(proxy.getRequireTLS())
-                       .roleArn(proxy.getRoleArn())
-                       .vpcSecurityGroupIds(proxy.getVpcSecurityGroupIds())
-                       .vpcSubnetIds(proxy.getVpcSubnetIds())
-                       .build();
+                .builder()
+                .auth(authModels)
+                .dBProxyArn(proxy.getDBProxyArn())
+                .dBProxyName(proxy.getDBProxyName())
+                .debugLogging(proxy.getDebugLogging())
+                .endpoint(proxy.getEndpoint())
+                .engineFamily(proxy.getEngineFamily())
+                .idleClientTimeout(proxy.getIdleClientTimeout())
+                .requireTLS(proxy.getRequireTLS())
+                .roleArn(proxy.getRoleArn())
+                .vpcId(proxy.getVpcId())
+                .vpcSecurityGroupIds(proxy.getVpcSecurityGroupIds())
+                .vpcSubnetIds(proxy.getVpcSubnetIds())
+                .build();
     }
 
     public static AuthFormat resultToModel(UserAuthConfigInfo auth) {
         return AuthFormat.builder()
-                   .authScheme(auth.getAuthScheme())
-                   .description(auth.getDescription())
-                   .iAMAuth(auth.getIAMAuth())
-                   .secretArn(auth.getSecretArn())
-                   .userName(auth.getUserName())
-                   .build();
+                .authScheme(auth.getAuthScheme())
+                .description(auth.getDescription())
+                .iAMAuth(auth.getIAMAuth())
+                .secretArn(auth.getSecretArn())
+                .userName(auth.getUserName())
+                .build();
     }
 
     public static List<UserAuthConfig> getUserAuthConfigs(ResourceModel model) {
@@ -55,11 +56,11 @@ public class Utility {
 
         for(AuthFormat auth : model.getAuth()){
             UserAuthConfig uac = new UserAuthConfig()
-                                         .withAuthScheme(auth.getAuthScheme())
-                                         .withDescription(auth.getDescription())
-                                         .withIAMAuth(auth.getIAMAuth())
-                                         .withSecretArn(auth.getSecretArn())
-                                         .withUserName(auth.getUserName());
+                    .withAuthScheme(auth.getAuthScheme())
+                    .withDescription(auth.getDescription())
+                    .withIAMAuth(auth.getIAMAuth())
+                    .withSecretArn(auth.getSecretArn())
+                    .withUserName(auth.getUserName());
             userAuthConfigList.add(uac);
         }
         return userAuthConfigList;

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/Matchers.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/Matchers.java
@@ -12,6 +12,7 @@ public class Matchers {
         assertThat(model.getDBProxyName()).isEqualTo(sdkModel.getDBProxyName());
         assertThat(model.getDBProxyArn()).isEqualTo(sdkModel.getDBProxyArn());
         assertThat(model.getRoleArn()).isEqualTo(sdkModel.getRoleArn());
+        assertThat(model.getVpcId()).isEqualTo(sdkModel.getVpcId());
         assertThat(model.getVpcSubnetIds()).isEqualTo(sdkModel.getVpcSubnetIds());
         assertThat(model.getVpcSecurityGroupIds()).isEqualTo(sdkModel.getVpcSecurityGroupIds());
     }

--- a/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/ReadHandlerTest.java
+++ b/aws-rds-dbproxy/src/test/java/software/amazon/rds/dbproxy/ReadHandlerTest.java
@@ -51,10 +51,11 @@ public class ReadHandlerTest {
         final ReadHandler handler = new ReadHandler();
 
         DBProxy proxy1 = new DBProxy().withDBProxyName("proxy1")
-                                      .withDBProxyArn("arn")
-                                      .withRoleArn("rolearn")
-                                      .withVpcSubnetIds("vpcsubnet1", "vpcsubnet2")
-                                      .withVpcSecurityGroupIds("sg1", "sg2");
+                .withDBProxyArn("arn")
+                .withRoleArn("rolearn")
+                .withVpcId("vpcId")
+                .withVpcSubnetIds("vpcsubnet1", "vpcsubnet2")
+                .withVpcSecurityGroupIds("sg1", "sg2");
         final List<DBProxy> existingProxies = ImmutableList.of(proxy1);
 
         doReturn(new DescribeDBProxiesResult().withDBProxies(existingProxies))
@@ -66,8 +67,8 @@ public class ReadHandlerTest {
         final ResourceModel model = ResourceModel.builder().dBProxyName("proxy1").build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                                                                      .desiredResourceState(model)
-                                                                      .build();
+                .desiredResourceState(model)
+                .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response
                 = handler.handleRequest(proxy, request, null, logger);
@@ -88,10 +89,11 @@ public class ReadHandlerTest {
         final ReadHandler handler = new ReadHandler();
 
         DBProxy proxy1 = new DBProxy().withDBProxyName("proxy1")
-                                      .withDBProxyArn("arn")
-                                      .withRoleArn("rolearn")
-                                      .withVpcSubnetIds("vpcsubnet1", "vpcsubnet2")
-                                      .withVpcSecurityGroupIds("sg1", "sg2");
+                .withDBProxyArn("arn")
+                .withRoleArn("rolearn")
+                .withVpcId("vpcId")
+                .withVpcSubnetIds("vpcsubnet1", "vpcsubnet2")
+                .withVpcSecurityGroupIds("sg1", "sg2");
         final List<DBProxy> existingProxies = ImmutableList.of(proxy1);
 
         doReturn(new DescribeDBProxiesResult().withDBProxies(existingProxies))
@@ -103,7 +105,7 @@ public class ReadHandlerTest {
         String tagKey2 = "tagKey2";
         String tagValue2 = "tagValue2";
         List<Tag> tagList = ImmutableList.of(new Tag().withKey(tagKey).withValue(tagValue),
-                                             new Tag().withKey(tagKey2).withValue(tagValue2));
+                new Tag().withKey(tagKey2).withValue(tagValue2));
         doReturn(new ListTagsForResourceResult().withTagList(tagList))
                 .when(proxy)
                 .injectCredentialsAndInvoke(any(ListTagsForResourceRequest.class), any(Function.class));
@@ -111,8 +113,8 @@ public class ReadHandlerTest {
         final ResourceModel model = ResourceModel.builder().dBProxyName("proxy1").build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                                                                      .desiredResourceState(model)
-                                                                      .build();
+                .desiredResourceState(model)
+                .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response
                 = handler.handleRequest(proxy, request, null, logger);
@@ -144,8 +146,8 @@ public class ReadHandlerTest {
         final ResourceModel model = ResourceModel.builder().dBProxyName("proxy1").build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                                                                      .desiredResourceState(model)
-                                                                      .build();
+                .desiredResourceState(model)
+                .build();
 
         assertThrows(CfnNotFoundException.class, () -> {
             handler.handleRequest(proxy, request, null, logger);

--- a/aws-rds-dbproxytargetgroup/.rpdk-config
+++ b/aws-rds-dbproxytargetgroup/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::RDS::DBProxyTargetGroup",
     "language": "java",
     "runtime": "java8",
@@ -12,5 +13,6 @@
             "dbproxytargetgroup"
         ],
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.rds.dbproxytargetgroup.HandlerWrapperExecutable"
 }

--- a/aws-rds-dbproxytargetgroup/aws-rds-dbproxytargetgroup.json
+++ b/aws-rds-dbproxytargetgroup/aws-rds-dbproxytargetgroup.json
@@ -34,7 +34,8 @@
           "description": "One or more SQL statements for the proxy to run when opening each new database connection.",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     }
   },
   "properties": {


### PR DESCRIPTION
*Description of changes:*
Add VPC Id property to proxy for proxy API update in aws-java-sdk-rds 1.11.971

adding "additionalProperties": false to proxy and targetGroup

tested by mvn package and mvn test. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
