### PR TITLE
Support MYSQL_CACHING_SHA2_PASSWORD in ClientPasswordAuthType

### DIFF
--- a/aws-rds-dbproxy/aws-rds-dbproxy.json
+++ b/aws-rds-dbproxy/aws-rds-dbproxy.json
@@ -35,6 +35,7 @@
           "type": "string",
           "enum": [
             "MYSQL_NATIVE_PASSWORD",
+            "MYSQL_CACHING_SHA2_PASSWORD",
             "POSTGRES_SCRAM_SHA_256",
             "POSTGRES_MD5",
             "SQL_SERVER_AUTHENTICATION"


### PR DESCRIPTION
*Issue #, if available:*
The value `MYSQL_CACHING_SHA2_PASSWORD` is not added in the Allowed list for property `ClientPasswordAuthType` for CloudFormation AWS::RDS::DBProxy resource type: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-rds-dbproxy-authformat.html#cfn-rds-dbproxy-authformat-clientpasswordauthtype

*Description of changes:*
Support `MYSQL_CACHING_SHA2_PASSWORD` in ClientPasswordAuthType

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
